### PR TITLE
Use relative path

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
-PUBLIC_PATH=/eBioDiv/demo
+PUBLIC_PATH=
 OUTPUT_DIR=demo
-VUE_APP_BACKEND_URL=https://tb.plazi.org/GgServer/gbifOccLinkData

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,1 @@
 OUTPUT_DIR=dev
-PUBLIC_PATH=/eBioDiv/dev

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="">
   <head>
     <meta charset="utf-8">
+    <% if (NODE_ENV === "production") { %><base href="/eBioDiv/demo/" /><%  } %>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,13 +10,6 @@ export default new Vuex.Store({
         secondary: "#008F00",
     },
     step: 1,
-    urls: {
-        institutions: process.env.VUE_APP_BACKEND_URL + "/institutionList",
-        datasets: process.env.VUE_APP_BACKEND_URL + "/datasets",
-        occurrences: process.env.VUE_APP_BACKEND_URL + "/occurrences",
-        matching: process.env.VUE_APP_BACKEND_URL + "/occurrenceRelations",
-        fetch_occurrence: process.env.VUE_APP_BACKEND_URL + "/occurrences",
-    },
     urls_parameters: {
         institution: null,
         format: null,


### PR DESCRIPTION
Allow to change the deploy the app to different location by just changing the URL in `<base url="...">` (in index.html).

Changes:
* in `.env`, `PUBLIC_PATH=` so the `publicPath` is an empty string.
* in development `<base url="...">` is omited: see `<% if (NODE_ENV === "production") { %><base href="/eBioDiv/demo/" /><%  } %>` in `public/index.html`. 


For information, it is deployed on candy from https://github.com/dalf/ebiodiv-matching-frontend/tree/dist
