### PR TITLE
Bug fix & update of the sandbox build

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PUBLIC_PATH=
 OUTPUT_DIR=dist/prod
-BACKEND_JSON=backend-production.json
+VUE_APP_BACKEND_JSON=backend-production.json
 VUE_APP_BASE_URL=/eBioDiv/demo/

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 PUBLIC_PATH=
 OUTPUT_DIR=dist/prod
 VUE_APP_BACKEND_JSON=backend-production.json
-VUE_APP_BASE_URL=/eBioDiv/demo/
+VUE_APP_BASE_URL=

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 PUBLIC_PATH=
 OUTPUT_DIR=dist/prod
 BACKEND_JSON=backend-production.json
+VUE_APP_BASE_URL=/eBioDiv/demo/

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 OUTPUT_DIR=dist/dev
-BACKEND_JSON=backend-sandbox.json
+VUE_APP_BACKEND_JSON=backend-sandbox.json
 VUE_APP_BASE_URL=

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 OUTPUT_DIR=dist/dev
 BACKEND_JSON=backend-sandbox.json
+VUE_APP_BASE_URL=

--- a/.env.sandbox
+++ b/.env.sandbox
@@ -1,4 +1,4 @@
 OUTPUT_DIR=dist/sandbox
-BACKEND_JSON=backend-sandbox.json
-NODE_ENV=production
+VUE_APP_BACKEND_JSON=backend-sandbox.json
 VUE_APP_BASE_URL=/eBioDiv/sandbox/
+NODE_ENV=production

--- a/.env.sandbox
+++ b/.env.sandbox
@@ -1,4 +1,4 @@
 OUTPUT_DIR=dist/sandbox
 VUE_APP_BACKEND_JSON=backend-sandbox.json
-VUE_APP_BASE_URL=/eBioDiv/sandbox/
+VUE_APP_BASE_URL=
 NODE_ENV=production

--- a/.env.sandbox
+++ b/.env.sandbox
@@ -1,2 +1,4 @@
 OUTPUT_DIR=dist/sandbox
 BACKEND_JSON=backend-sandbox.json
+NODE_ENV=production
+VUE_APP_BASE_URL=/eBioDiv/sandbox/

--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
-<html lang="">
+<html lang="en">
   <head>
     <meta charset="utf-8">
-    <% if (NODE_ENV === "production") { %><base href="/eBioDiv/demo/" /><%  } %>
-    <% if (NODE_ENV === "sandbox") { %><base href="/eBioDiv/sandbox/" /><%  } %>
+    <% if (VUE_APP_BASE_URL !== "") { %><base href="<%= VUE_APP_BASE_URL %>" /><%  } %>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">

--- a/src/components/BannerComponent.vue
+++ b/src/components/BannerComponent.vue
@@ -1,5 +1,5 @@
 <template>
-    <div  class="banner" :style="cssVars">
+    <div  :class="bannerCssClasses" :style="cssVars">
 
     <div class="row">
         <div class="col-12">
@@ -40,8 +40,12 @@ import { mapState } from 'vuex'
                     '--color-main': this.theme_color.main,
                     '--color-secondary': this.theme_color.secondary,
                 }
-            }
-      }
+            },
+            bannerCssClasses() {
+                // return "banner productionBackend";
+                return "banner " + process.env.VUE_APP_BACKEND_JSON.replace(".json", "").replace("backend-", "") + "Backend";
+            },
+        }
     }
 
 </script>
@@ -50,13 +54,34 @@ import { mapState } from 'vuex'
 <style scoped lang="scss">
 
     .banner{
-        background: conic-gradient(at 0% 30%, var(--color-secondary) 10%, var(--color-main) 30%, var(--color-secondary) 50%);
+        background: var(--color-secondary);
         color: #FFFFFF;
         padding: 10px 20px 10px 20px;
         height: 150px;
         margin-bottom: 10px;
+    }
 
+    .banner.productionBackend {
+        background: conic-gradient(at 0% 30%, var(--color-secondary) 10%, var(--color-main) 30%, var(--color-secondary) 50%);
+    }
 
+    .banner.sandboxBackend {
+        background: repeating-linear-gradient(
+            -45deg,
+            var(--color-main),
+            var(--color-main) 15px,
+            var(--color-secondary) 15px,
+            var(--color-secondary) 30px
+        );
+    }
+
+    .banner.sandboxBackend:after {
+        content: "Sandbox";
+        display: block;
+        position: absolute;
+        right: 1rem;
+        top: 7.5rem;
+        font-size: 1rem;
     }
 
     .row {

--- a/vue.config.js
+++ b/vue.config.js
@@ -7,7 +7,7 @@ module.exports = {
         plugins: [
             new CopyPlugin({
                 patterns: [
-                    { from: process.env.BACKEND_JSON, to: "backend.json" },
+                    { from: process.env.VUE_APP_BACKEND_JSON, to: "backend.json" },
                 ],
             })
         ]


### PR DESCRIPTION
The sandbox environment is missing `<base href="...">`.
This PR fixes that.

In addition, the javascript optimization are similar between production and sandbox.

Fix https://github.com/bitem-heg-geneve/ebiodiv-matching-frontend/pull/33

---

In addition, when the front-end is connected to the sandbox backend, the banner is different to avoid the confusion with the production:
![image](https://user-images.githubusercontent.com/1594191/188840177-895ea47d-a484-46ef-9fa0-8badaaa17820.png)

In dev, it is still possible to display the production banner by changing the `bannerCssClasses` :

```js
            bannerCssClasses() {
                // return "banner productionBackend";
                return "banner " + process.env.VUE_APP_BACKEND_JSON.replace(".json", "").replace("backend-", "") + "Backend";
            },
```

* comment out the `return "banner ".....`
* uncomment `return "banner productionBackend";`

In production, the banner is same as before:
![image](https://user-images.githubusercontent.com/1594191/188841594-65abba8a-5ae6-4896-a517-8eb9929e1b8f.png)
