### PR TITLE
Send new occurrence relations to a SIB backend

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,3 +2,4 @@ OUTPUT_DIR=dist/dev
 VUE_APP_BACKEND_JSON=backend-sandbox.json
 VUE_APP_BASE_URL=
 VUE_APP_ORCID_JSON=orcid-sandbox.json
+VUE_APP_SIB_BACKEND_URL=http://localhost:8888/

--- a/backend-production.json
+++ b/backend-production.json
@@ -2,5 +2,6 @@
     "institutions": "https://tb.plazi.org/GbifOccLink/data/institutionList",
     "datasets": "https://tb.plazi.org/GbifOccLink/data/datasets",
     "occurrences": "https://tb.plazi.org/GbifOccLink/data/occurrences",
-    "matching": "https://tb.plazi.org/GbifOccLink/data/occurrenceRelations"
+    "matching": "https://tb.plazi.org/GbifOccLink/data/occurrenceRelations",
+    "sib_backend_url": "api/"
 }

--- a/backend-sandbox.json
+++ b/backend-sandbox.json
@@ -2,5 +2,6 @@
     "institutions": "https://tb.plazi.org/GbifOccLink/sandbox/institutionList",
     "datasets": "https://tb.plazi.org/GbifOccLink/sandbox/datasets",
     "occurrences": "https://tb.plazi.org/GbifOccLink/sandbox/occurrences",
-    "matching": "https://tb.plazi.org/GbifOccLink/sandbox/occurrenceRelations"
+    "matching": "https://tb.plazi.org/GbifOccLink/sandbox/occurrenceRelations",
+    "sib_backend_url": "api/"
 }

--- a/src/services/backend.js
+++ b/src/services/backend.js
@@ -66,6 +66,17 @@ export default new class Backend {
         return await axios.post(this.urls.matching, data)
     }
 
+    async post_sib_matching(data) {
+        let sib_backend_url = process.env.VUE_APP_SIB_BACKEND_URL;
+        if (sib_backend_url == null || sib_backend_url == "") {
+            await this.fetch_urls()
+            sib_backend_url = this.urls.sib_backend_url
+        }
+        if (sib_backend_url != null) {
+            return await axios.post(sib_backend_url + "newOcurrenceRelations", data)
+        }
+    }
+
     processOccurrences(json, format_selection) {
         const subjectOccs = {}
         const subjectStatus = {}


### PR DESCRIPTION
Example:
* an occurrence is related to 4 others
* an user decides than a one of the 4 occurrences is related, and doesn't take a decision for 3 others

The Plazi backend receives one what has been decided by the user.
The SIB backend receives the 4 occurrences, with the existing decisions and the new one(s).

The HTTP requests are sent in parallel.

Fields:
  * `decision` can be `true`, `false` or `null`
  * `is_new_decision` can be `true` or `false`  (`true` when the user has made the decision right now)

Note: the user name and ORCID are sent (and will be stored). Does it require some notice to the user?

SIB backend purpose: collect human curated data to train a new matching algorithm (that's the server needs a copy of the occurrence).

This PR requires to deploy the SIB backend, see https://github.com/bitem-heg-geneve/ebiodiv-matching-backend/pull/3

---

<details>

<summary>Example of payload</summary>

```json
{
    "institutionKey": "530c45d0-e0f7-401d-b3f6-34f58482c485",
    "datasetKey": "750b7bfc-3577-4b26-8aaf-3e4be9f0d639",
    "user": {
        "name": "Alex",
        "orcid": null
    },
    "refOccurrence": {
        "datasetKey": "750b7bfc-3577-4b26-8aaf-3e4be9f0d639",
        "publishingOrgKey": "814cdfb5-d4f8-4453-815f-ea5df98e76bf",
        "installationKey": "3056a1fb-d172-4927-8f52-92246f9c768b",
        "publishingCountry": "US",
        "protocol": "DWC_ARCHIVE",
        "lastCrawled": "2022-08-16T23:26:54.742+00:00",
        "lastParsed": "2022-08-16T23:31:16.489+00:00",
        "crawlId": 269,
        "hostingOrganizationKey": "96710dc8-fecb-440d-ae3e-c34ae8a9616f",
        "extensions": {},
        "basisOfRecord": "PRESERVED_SPECIMEN",
        "occurrenceStatus": "PRESENT",
        "lifeStage": "Adult",
        "taxonKey": 11371545,
        "kingdomKey": 1,
        "phylumKey": 54,
        "classKey": 216,
        "orderKey": 1470,
        "familyKey": 7854,
        "genusKey": 4440715,
        "speciesKey": 11371545,
        "acceptedTaxonKey": 11371545,
        "scientificName": "Baeocera vintercepta Lobl, 2021",
        "acceptedScientificName": "Baeocera vintercepta Lobl, 2021",
        "kingdom": "Animalia",
        "phylum": "Arthropoda",
        "order": "Coleoptera",
        "family": "Staphylinidae",
        "genus": "Baeocera",
        "species": "Baeocera vintercepta",
        "genericName": "Baeocera",
        "specificEpithet": "vintercepta",
        "taxonRank": "SPECIES",
        "taxonomicStatus": "ACCEPTED",
        "iucnRedListCategory": "NE",
        "dateIdentified": "2020-01-01T00:00:00",
        "decimalLongitude": -111.016,
        "decimalLatitude": 31.531,
        "coordinateUncertaintyInMeters": 50,
        "elevation": 1439,
        "stateProvince": "Arizona",
        "year": 2018,
        "month": 7,
        "day": 11,
        "eventDate": "2018-07-11T00:00:00",
        "typeStatus": "PARATYPE",
        "issues": ["INSTITUTION_MATCH_FUZZY", "COLLECTION_MATCH_FUZZY"],
        "modified": "2021-05-25T16:17:30.000+00:00",
        "lastInterpreted": "2022-08-16T23:31:16.489+00:00",
        "references": "https://serv.biokic.asu.edu/ecdysis/collections/individual/index.php?occid=694912",
        "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
        "identifiers": [],
        "media": [],
        "facts": [],
        "gadm": {
            "level0": {
                "gid": "USA",
                "name": "United States"
            },
            "level1": {
                "gid": "USA.3_1",
                "name": "Arizona"
            },
            "level2": {
                "gid": "USA.3.13_1",
                "name": "Santa Cruz"
            }
        },
        "institutionKey": "530c45d0-e0f7-401d-b3f6-34f58482c485",
        "collectionKey": "8d0f46f7-9df8-495f-b53b-9b5bf767004a",
        "isInCluster": true,
        "recordedBy": "W.B. Warner",
        "identifiedBy": "Lobl",
        "geodeticDatum": "WGS84",
        "class": "Insecta",
        "countryCode": "US",
        "recordedByIDs": [],
        "identifiedByIDs": [],
        "country": "United States of America",
        "identifier": "694912",
        "verbatimEventDate": "July 11-16, 2018",
        "georeferencedBy": "Sangmi Lee",
        "endDayOfYear": "-31",
        "http://unknown.org/recordID": "urn:uuid:74a9a878-3293-433d-a500-a6028fbcdc0b",
        "county": "Santa Cruz County",
        "locality": "Palo Prado Road, E side Santa Cruz Road",
        "gbifID": "3118644418",
        "collectionCode": "ASUHIC",
        "occurrenceID": "74a9a878-3293-433d-a500-a6028fbcdc0b",
        "taxonID": "1637457",
        "catalogNumber": "ASUHIC0163854",
        "institutionCode": "ASU",
        "rights": "http://creativecommons.org/publicdomain/zero/1.0/",
        "startDayOfYear": "192",
        "occurrenceRemarks": "V-flight intercept trap",
        "http://unknown.org/recordEnteredBy": "sangmi.lee",
        "verbatimElevation": "4722'",
        "higherClassification": "Animalia|Arthropoda|Hexapoda|Insecta|Pterygota|Neoptera|Coleoptera|Polyphaga|Staphyliniformia|Staphylinoidea|Staphylinidae|Scaphidiinae|Scaphisomatini|Baeocera",
        "collectionID": "71ca74c2-208d-4784-998f-6f7ecc6ec090",
        "georeferenceSources": "Label",
        "key": 3118644418,
        "status": "partial",
        "processed_facets": {
            "date": [2018],
            "datasetName": [],
            "status": ["partial"],
            "country": ["United States of America"],
            "collectionCode": ["ASUHIC"],
            "recordedBy": ["W.B. Warner"],
            "typeStatus": ["PARATYPE"],
            "kingdom": ["Animalia"],
            "phylum": ["Arthropoda"],
            "class": ["Insecta"],
            "order": ["Coleoptera"],
            "family": ["Staphylinidae"],
            "genus": ["Baeocera"],
            "species": ["Baeocera vintercepta"]
        }
    },
    "relations": {
        "3398243303": {
            "occurrence": {
                "datasetKey": "dc575a8c-e0d1-45dc-9648-9cc1c3812b44",
                "publishingOrgKey": "7ce8aef0-9e92-11dc-8738-b8a03c50a862",
                "installationKey": "7ce8aef1-9e92-11dc-8740-b8a03c50a999",
                "publishingCountry": "CH",
                "protocol": "DWC_ARCHIVE",
                "lastCrawled": "2022-08-16T03:45:07.961+00:00",
                "lastParsed": "2022-08-16T03:45:55.364+00:00",
                "crawlId": 49,
                "hostingOrganizationKey": "7ce8aef0-9e92-11dc-8738-b8a03c50a862",
                "extensions": {},
                "basisOfRecord": "MATERIAL_CITATION",
                "individualCount": 1,
                "occurrenceStatus": "PRESENT",
                "taxonKey": 11371545,
                "kingdomKey": 1,
                "phylumKey": 54,
                "classKey": 216,
                "orderKey": 1470,
                "familyKey": 7854,
                "genusKey": 4440715,
                "speciesKey": 11371545,
                "acceptedTaxonKey": 11371545,
                "scientificName": "Baeocera vintercepta Lobl, 2021",
                "acceptedScientificName": "Baeocera vintercepta Lobl, 2021",
                "kingdom": "Animalia",
                "phylum": "Arthropoda",
                "order": "Coleoptera",
                "family": "Staphylinidae",
                "genus": "Baeocera",
                "species": "Baeocera vintercepta",
                "genericName": "Baeocera",
                "specificEpithet": "vintercepta",
                "taxonRank": "SPECIES",
                "taxonomicStatus": "ACCEPTED",
                "iucnRedListCategory": "NE",
                "year": 2018,
                "month": 8,
                "day": 3,
                "eventDate": "2018-08-03T00:00:00",
                "typeStatus": "PARATYPE",
                "issues": ["OCCURRENCE_STATUS_INFERRED_FROM_INDIVIDUAL_COUNT"],
                "lastInterpreted": "2022-08-16T03:45:55.364+00:00",
                "references": "http://treatment.plazi.org/id/03F58796FF96FFE6FEE4FDB313C6F952",
                "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
                "identifiers": [],
                "media": [],
                "facts": [],
                "gadm": {},
                "isInCluster": true,
                "recordedBy": "W. B. Warner",
                "class": "Insecta",
                "countryCode": "US",
                "recordedByIDs": [],
                "identifiedByIDs": [],
                "country": "United States of America",
                "http://unknown.org/combinationAuthors": "Lobl",
                "identifier": "03F58796FF96FFE6FEE4FDB313C6F952.mc.3B343CDDFF96FFE6FF71FC831523FC14",
                "locality": "Santa Cruz R.",
                "gbifID": "3398243303",
                "occurrenceID": "03F58796FF96FFE6FEE4FDB313C6F952.mc.3B343CDDFF96FFE6FF71FC831523FC14",
                "http://unknown.org/verbatimScientificName": "Baeocera vintercepta Löbl",
                "taxonID": "03F58796FF96FFE6FEE4FDB313C6F952.taxon",
                "http://unknown.org/canonicalName": "Baeocera vintercepta",
                "verbatimLabel": "82; Santa Cruz R.; 31.3757 °, - 110.8406 ° Aug. 3 - 14. 2018; V-flight intercept trap; W. B. Warner.",
                "http://unknown.org/combinationYear": "2021",
                "key": 3398243303
            },
            "decision": true,
            "is_new_decision": true
        },
        "3398243328": {
            "occurrence": {
                "datasetKey": "dc575a8c-e0d1-45dc-9648-9cc1c3812b44",
                "publishingOrgKey": "7ce8aef0-9e92-11dc-8738-b8a03c50a862",
                "installationKey": "7ce8aef1-9e92-11dc-8740-b8a03c50a999",
                "publishingCountry": "CH",
                "protocol": "DWC_ARCHIVE",
                "lastCrawled": "2022-08-16T03:45:07.961+00:00",
                "lastParsed": "2022-08-16T03:45:55.399+00:00",
                "crawlId": 49,
                "hostingOrganizationKey": "7ce8aef0-9e92-11dc-8738-b8a03c50a862",
                "extensions": {},
                "basisOfRecord": "MATERIAL_CITATION",
                "individualCount": 1,
                "occurrenceStatus": "PRESENT",
                "sex": "MALE",
                "taxonKey": 11371545,
                "kingdomKey": 1,
                "phylumKey": 54,
                "classKey": 216,
                "orderKey": 1470,
                "familyKey": 7854,
                "genusKey": 4440715,
                "speciesKey": 11371545,
                "acceptedTaxonKey": 11371545,
                "scientificName": "Baeocera vintercepta Lobl, 2021",
                "acceptedScientificName": "Baeocera vintercepta Lobl, 2021",
                "kingdom": "Animalia",
                "phylum": "Arthropoda",
                "order": "Coleoptera",
                "family": "Staphylinidae",
                "genus": "Baeocera",
                "species": "Baeocera vintercepta",
                "genericName": "Baeocera",
                "specificEpithet": "vintercepta",
                "taxonRank": "SPECIES",
                "taxonomicStatus": "ACCEPTED",
                "iucnRedListCategory": "NE",
                "stateProvince": "Az",
                "typeStatus": "PARATYPE",
                "issues": ["RECORDED_DATE_INVALID", "OCCURRENCE_STATUS_INFERRED_FROM_INDIVIDUAL_COUNT"],
                "lastInterpreted": "2022-08-16T03:45:55.399+00:00",
                "references": "http://treatment.plazi.org/id/03F58796FF96FFE6FEE4FDB313C6F952",
                "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
                "identifiers": [],
                "media": [],
                "facts": [],
                "gadm": {},
                "isInCluster": true,
                "recordedBy": "W. B. Warner",
                "class": "Insecta",
                "countryCode": "US",
                "recordedByIDs": [],
                "identifiedByIDs": [],
                "country": "United States of America",
                "http://unknown.org/combinationAuthors": "Lobl",
                "identifier": "03F58796FF96FFE6FEE4FDB313C6F952.mc.3B343CDDFF96FFE6FF71FBE415ABFBD4",
                "municipality": "Sunflower",
                "locality": "Maricopa Co.",
                "gbifID": "3398243328",
                "collectionCode": "WBWC",
                "occurrenceID": "03F58796FF96FFE6FEE4FDB313C6F952.mc.3B343CDDFF96FFE6FF71FBE415ABFBD4",
                "http://unknown.org/verbatimScientificName": "Baeocera vintercepta Löbl",
                "taxonID": "03F58796FF96FFE6FEE4FDB313C6F952.taxon",
                "http://unknown.org/canonicalName": "Baeocera vintercepta",
                "verbatimLabel": "– WBWC; 1 male; USA: AZ: Maricopa Co. along Sycamore Creek at Sunflower; 33.8651 °, - 111.4657 °; Jul. 16 - Aug. 4.2019; V-flight intercept trap; W. B. Warner.",
                "http://unknown.org/combinationYear": "2021",
                "key": 3398243328
            },
            "decision": false,
            "is_new_decision": false
        },
        "3398243333": {
            "occurrence": {
                "datasetKey": "dc575a8c-e0d1-45dc-9648-9cc1c3812b44",
                "publishingOrgKey": "7ce8aef0-9e92-11dc-8738-b8a03c50a862",
                "installationKey": "7ce8aef1-9e92-11dc-8740-b8a03c50a999",
                "publishingCountry": "CH",
                "protocol": "DWC_ARCHIVE",
                "lastCrawled": "2022-08-16T03:45:07.961+00:00",
                "lastParsed": "2022-08-16T03:45:55.406+00:00",
                "crawlId": 49,
                "hostingOrganizationKey": "7ce8aef0-9e92-11dc-8738-b8a03c50a862",
                "extensions": {},
                "basisOfRecord": "MATERIAL_CITATION",
                "individualCount": 5,
                "occurrenceStatus": "PRESENT",
                "sex": "MALE",
                "taxonKey": 11371545,
                "kingdomKey": 1,
                "phylumKey": 54,
                "classKey": 216,
                "orderKey": 1470,
                "familyKey": 7854,
                "genusKey": 4440715,
                "speciesKey": 11371545,
                "acceptedTaxonKey": 11371545,
                "scientificName": "Baeocera vintercepta Lobl, 2021",
                "acceptedScientificName": "Baeocera vintercepta Lobl, 2021",
                "kingdom": "Animalia",
                "phylum": "Arthropoda",
                "order": "Coleoptera",
                "family": "Staphylinidae",
                "genus": "Baeocera",
                "species": "Baeocera vintercepta",
                "genericName": "Baeocera",
                "specificEpithet": "vintercepta",
                "taxonRank": "SPECIES",
                "taxonomicStatus": "ACCEPTED",
                "iucnRedListCategory": "NE",
                "typeStatus": "PARATYPE",
                "issues": ["OCCURRENCE_STATUS_INFERRED_FROM_INDIVIDUAL_COUNT"],
                "lastInterpreted": "2022-08-16T03:45:55.406+00:00",
                "references": "http://treatment.plazi.org/id/03F58796FF96FFE6FEE4FDB313C6F952",
                "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
                "identifiers": [],
                "media": [],
                "facts": [],
                "gadm": {},
                "isInCluster": true,
                "class": "Insecta",
                "countryCode": "US",
                "recordedByIDs": [],
                "identifiedByIDs": [],
                "country": "United States of America",
                "http://unknown.org/combinationAuthors": "Lobl",
                "identifier": "03F58796FF96FFE6FEE4FDB313C6F952.mc.3B343CDDFF96FFE6FF71FCC515AFFCD4",
                "locality": "Santa Cruz Co. Duquesne Rd.",
                "gbifID": "3398243333",
                "collectionCode": "MHNG",
                "occurrenceID": "03F58796FF96FFE6FEE4FDB313C6F952.mc.3B343CDDFF96FFE6FF71FCC515AFFCD4",
                "http://unknown.org/verbatimScientificName": "Baeocera vintercepta Löbl",
                "taxonID": "03F58796FF96FFE6FEE4FDB313C6F952.taxon",
                "http://unknown.org/canonicalName": "Baeocera vintercepta",
                "verbatimLabel": "Paratypes: MHNG; 3 males, 2 females; USA: AZ: Santa Cruz Co. Duquesne Rd., 2.3 rd. mi E jct. Hwy",
                "http://unknown.org/combinationYear": "2021",
                "key": 3398243333
            },
            "decision": false,
            "is_new_decision": false
        },
        "3398243347": {
            "occurrence": {
                "datasetKey": "dc575a8c-e0d1-45dc-9648-9cc1c3812b44",
                "publishingOrgKey": "7ce8aef0-9e92-11dc-8738-b8a03c50a862",
                "installationKey": "7ce8aef1-9e92-11dc-8740-b8a03c50a999",
                "publishingCountry": "CH",
                "protocol": "DWC_ARCHIVE",
                "lastCrawled": "2022-08-16T03:45:07.961+00:00",
                "lastParsed": "2022-08-16T03:45:55.417+00:00",
                "crawlId": 49,
                "hostingOrganizationKey": "7ce8aef0-9e92-11dc-8738-b8a03c50a862",
                "extensions": {},
                "basisOfRecord": "MATERIAL_CITATION",
                "individualCount": 1,
                "occurrenceStatus": "PRESENT",
                "sex": "MALE",
                "taxonKey": 11371545,
                "kingdomKey": 1,
                "phylumKey": 54,
                "classKey": 216,
                "orderKey": 1470,
                "familyKey": 7854,
                "genusKey": 4440715,
                "speciesKey": 11371545,
                "acceptedTaxonKey": 11371545,
                "scientificName": "Baeocera vintercepta Lobl, 2021",
                "acceptedScientificName": "Baeocera vintercepta Lobl, 2021",
                "kingdom": "Animalia",
                "phylum": "Arthropoda",
                "order": "Coleoptera",
                "family": "Staphylinidae",
                "genus": "Baeocera",
                "species": "Baeocera vintercepta",
                "genericName": "Baeocera",
                "specificEpithet": "vintercepta",
                "taxonRank": "SPECIES",
                "taxonomicStatus": "ACCEPTED",
                "iucnRedListCategory": "NE",
                "stateProvince": "Az",
                "year": 2018,
                "month": 7,
                "day": 11,
                "eventDate": "2018-07-11T00:00:00",
                "typeStatus": "PARATYPE",
                "issues": ["OCCURRENCE_STATUS_INFERRED_FROM_INDIVIDUAL_COUNT"],
                "lastInterpreted": "2022-08-16T03:45:55.417+00:00",
                "references": "http://treatment.plazi.org/id/03F58796FF96FFE6FEE4FDB313C6F952",
                "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
                "identifiers": [],
                "media": [],
                "facts": [],
                "gadm": {},
                "isInCluster": true,
                "recordedBy": "W. B. Warner",
                "class": "Insecta",
                "countryCode": "US",
                "recordedByIDs": [],
                "identifiedByIDs": [],
                "country": "United States of America",
                "http://unknown.org/combinationAuthors": "Lobl",
                "identifier": "03F58796FF96FFE6FEE4FDB313C6F952.mc.3B343CDDFF96FFE6FD64FC6415AFFBB3",
                "municipality": "Santa Cruz",
                "locality": "Palo Prado Rd.",
                "gbifID": "3398243347",
                "collectionCode": "MHNG",
                "occurrenceID": "03F58796FF96FFE6FEE4FDB313C6F952.mc.3B343CDDFF96FFE6FD64FC6415AFFBB3",
                "http://unknown.org/verbatimScientificName": "Baeocera vintercepta Löbl",
                "taxonID": "03F58796FF96FFE6FEE4FDB313C6F952.taxon",
                "http://unknown.org/canonicalName": "Baeocera vintercepta",
                "verbatimLabel": "– MHNG; 1 male; USA: AZ: Santa Cruz Co. Palo Prado Rd., east side Santa Cruz R.; 31.531 °, 111.016 °; July 11 - 16, 2018; V-flight intercept trap; W. B. Warner (MHNG);",
                "http://unknown.org/combinationYear": "2021",
                "key": 3398243347
            },
            "decision": false,
            "is_new_decision": true
        }
    }
}
```

</details>
