### PR TITLE
Fix: update the facet counters when the users change the facet selection

### DIFF
--- a/src/components/FacetsComponent.vue
+++ b/src/components/FacetsComponent.vue
@@ -152,6 +152,8 @@ export default {
         return {
             visible_facets: true,
             facets: {},
+            cache_facets_multi_with_status: {},
+            cache_facets_with_status: {},
         };
     },
     computed: {
@@ -165,11 +167,10 @@ export default {
             return (this.collection_name + "_sort-group")
         },
         facets_multi_with_status() {
-            const cache = {}
             return (facet_element) => {
                 const facet_name = facet_element.short
-                if (cache[facet_name] != null) {
-                    return cache[facet_name];
+                if (this.cache_facets_multi_with_status[facet_name] != null) {
+                    return this.cache_facets_multi_with_status[facet_name];
                 }
 
                 // Get filtered documents list (but not for the selected facet)
@@ -193,17 +194,15 @@ export default {
 
                 // Create the facet lists based on the facets of the set + what is selected
                 var results = this.createFacetList(value_list, this.user_selection.facets[facet_name], labelMethod)
-
-                cache[facet_name] = results;
+                this.cache_facets_multi_with_status[facet_name] = Object.freeze(results);
                 return results
             }
         },
         facets_with_status() {
-            const cache = {}
             return (facet_element) => {
                 var facet_name = facet_element.short
-                if (cache[facet_name] != null) {
-                    return cache[facet_name];
+                if (this.cache_facets_with_status[facet_name] != null) {
+                    return this.cache_facets_with_status[facet_name];
                 }
 
                 // Get filtered documents list
@@ -221,7 +220,7 @@ export default {
 
                 // Create the facet lists based on the facets of the set + what is selected
                 var results = this.createFacetList(value_list, this.user_selection.facets[facet_name], labelMethod)
-                cache[facet_name] = results;
+                this.cache_facets_with_status[facet_name] = results;
                 return results
             }
         },
@@ -281,7 +280,9 @@ export default {
                     }
                 }
             }
-            this.updateFacet(Object.freeze({ 'facet': facet_name, 'list': filter_list }))
+            this.cache_facets_with_status = {}
+            this.cache_facets_multi_with_status = {}
+            this.updateFacet(Object.freeze({'facet': facet_name, 'list': filter_list }))
         }
     }
 }


### PR DESCRIPTION
Previously the counter for each facet were not updated when the users selected different facets:

| Initial | After selecting the country |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/1594191/203002835-ad0d1cc1-76a0-47c4-9552-f2afd029fc03.png) | ![image](https://user-images.githubusercontent.com/1594191/203003136-8be2c569-7cb7-4314-a2f5-cfc7fa16f7cf.png) |

For example, see "Collections code" counter :
* 2 for Invertebrates (719 before)
* 2 for Arachnology (201 before)


Close https://github.com/bitem-heg-geneve/ebiodiv-matching-frontend/issues/58