### PR TITLE
Add Google Analytics

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ OUTPUT_DIR=dist/prod
 VUE_APP_BACKEND_JSON=backend-production.json
 VUE_APP_BASE_URL=/
 VUE_APP_ORCID_JSON=orcid-production.json
+VUE_APP_GA_ID=G-YC8R2FDN92

--- a/.env.development
+++ b/.env.development
@@ -3,3 +3,4 @@ VUE_APP_BACKEND_JSON=backend-sandbox.json
 VUE_APP_BASE_URL=
 VUE_APP_ORCID_JSON=orcid-sandbox.json
 VUE_APP_SIB_BACKEND_URL=http://localhost:8888/
+VUE_APP_GA_ID=G-54DZSQ26Q5

--- a/.env.sandbox
+++ b/.env.sandbox
@@ -2,4 +2,5 @@ OUTPUT_DIR=dist/sandbox
 VUE_APP_BACKEND_JSON=backend-sandbox.json
 VUE_APP_BASE_URL=/
 VUE_APP_ORCID_JSON=orcid-production.json
+VUE_APP_GA_ID=G-YS8NQP80R5
 NODE_ENV=production

--- a/package-lock.json
+++ b/package-lock.json
@@ -12260,6 +12260,11 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tiny-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tiny-cookie/-/tiny-cookie-2.3.2.tgz",
+      "integrity": "sha512-qbymkVh+6+Gc/c9sqnvbG+dOHH6bschjphK3SHgIfT6h/t+63GBL37JXNoXEc6u/+BcwU6XmaWUuf19ouLVtPg=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12784,6 +12789,14 @@
       "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
       "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w=="
     },
+    "vue-cookie-accept-decline": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/vue-cookie-accept-decline/-/vue-cookie-accept-decline-5.4.0.tgz",
+      "integrity": "sha512-TbpApiW8APhYvuGPENgfHsJfKOQrdOFqHgM6gRJpEz/3ef55IilvdoJjhSna8xBP+u6pbRpUM5cFAtXnZkVt9Q==",
+      "requires": {
+        "tiny-cookie": "^2.1.2"
+      }
+    },
     "vue-eslint-parser": {
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
@@ -12815,6 +12828,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",
       "integrity": "sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA=="
+    },
+    "vue-gtag": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/vue-gtag/-/vue-gtag-1.16.1.tgz",
+      "integrity": "sha512-5vs0pSGxdqrfXqN1Qwt0ZFXG0iTYjRMu/saddc7QIC5yp+DKgjWQRpGYVa7Pq+KbThxwzzMfo0sGi7ISa6NowA=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "string-metric": "^0.3.3",
     "v-autocomplete": "^1.8.2",
     "vue": "^2.6.14",
+    "vue-cookie-accept-decline": "^5.4.0",
+    "vue-gtag": "^1.16.1",
     "vue-plain-pagination": "^0.3.0",
     "vue-router": "^3.2.0",
     "vue-select": "^3.16.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,15 +43,20 @@
       </div>
     </div>
 
-
+    <CookieConsentElement></CookieConsentElement>
+  
   </div>
 
 </template>
 
 <script>
 import { mapState } from 'vuex'
+import CookieConsentElement from '@/components/CookieConsentElement.vue'
 
 export default {
+  components: {
+    CookieConsentElement,
+  },
   computed: {
     ...mapState(['theme_color']),
     cssVars() {
@@ -61,7 +66,6 @@ export default {
     }
   }
 }
-
 </script>
 
 

--- a/src/components/CookieConsentElement.vue
+++ b/src/components/CookieConsentElement.vue
@@ -1,0 +1,140 @@
+<template>
+    <div>
+        <vue-cookie-accept-decline
+            :debug="false"
+            :disableDecline="false"
+            :showPostponeButton="false"
+            @clicked-accept="cookieClickedAccept"
+            @clicked-decline="cookieClickedDecline"
+            @removed-cookie="cookieRemovedCookie"
+            @status="cookieStatus"
+            elementId="tracking_consent"
+            position="bottom"
+            ref="tracking_consent"
+            transitionName="slideFromBottom"
+            type="bar">
+            <template #message>
+                <p><b>Do you accept cookies that measure website use ?</b></p>
+                <p>
+                    We use <a href="https://marketingplatform.google.com/about/analytics/" target="_blank">Google Analytics</a> to
+                    measure how you use the website so we can improve it based on user needs. Google
+                    Analytics sets cookies that store anonymised information about how you got to the site, the pages you visit,
+                    how long you spend on each page and what you click on while you're visiting the site.
+                </p>
+            </template>
+            <template #declineContent>Reject</template>
+            <template #acceptContent>Accept</template>
+        </vue-cookie-accept-decline>
+        <div id="cookie_management">
+            <!-- License: CC0 License , https://www.svgrepo.com/svg/30963/cookie -->
+            <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 417 417" v-b-modal="this.user_tracking_consent === 'accept' ? 'cookieDecline' : 'cookieAccept'">
+                <path fill="#d4b783" d="M345 204a59 59 0 0 1-85-48 60 60 0 0 1-48-85c-13-8-21-21-24-36-42 2-80 17-111 41a42 42 0 0 1-29 72c-6 0-12-1-17-3a187 187 0 0 0-11 63 189 189 0 0 0 333 122 42 42 0 0 1-10-59 42 42 0 0 1 34-17h1c2-9 3-17 3-26-15-3-28-11-36-24zM132 335c-13 0-24-6-32-16a42 42 0 1 1 65-54c6 8 9 18 9 28 0 23-18 42-42 42zm28-151c-13 0-25-6-32-16-7-7-10-17-10-27a42 42 0 0 1 74-26 42 42 0 0 1-32 69zm87 131c-17 0-32-8-42-20a54 54 0 1 1 83-69 54 54 0 0 1-41 89z"/>
+                <path fill="#89634a" d="M160 163a22 22 0 1 0 0-44 22 22 0 0 0 0 44zm-28 151a22 22 0 1 0 0-44 22 22 0 0 0 0 44zM70 106c0-6-3-12-8-16-9 11-17 23-23 36a22 22 0 0 0 31-20zm285 190c0 7 4 14 10 18 8-12 15-25 20-39l-8-1c-12 0-22 9-22 22zm-109-2a34 34 0 1 0 0-68 34 34 0 0 0 0 68z"/>
+                <path fill="#89634a" d="M192 115c6 7 10 16 10 26a42 42 0 0 1-74 27 42 42 0 1 0 64-53zm-18 177a42 42 0 0 1-74 27 42 42 0 1 0 64-53c6 7 10 16 10 26zm126-32a54 54 0 0 1-95 35 54 54 0 1 0 83-69c8 9 12 21 12 34z"/>
+                <path d="M160 183a42 42 0 1 0 0-84 42 42 0 0 0 0 84zm0-64a22 22 0 1 1 0 44 22 22 0 0 1 0-44zm-28 215a42 42 0 1 0 0-84 42 42 0 0 0 0 84zm0-64a22 22 0 1 1 0 44 22 22 0 0 1 0-44z"/>
+                <path d="M417 207v-1c0-6-4-10-10-10-14-1-28-10-34-23a10 10 0 0 0-15-4 41 41 0 0 1-43 2c-13-8-21-23-20-39a10 10 0 0 0-10-10 40 40 0 0 1-37-63 10 10 0 0 0-4-15c-13-6-22-20-23-34 0-6-4-10-10-10h-3a209 209 0 1 0 209 207zM62 90a22 22 0 0 1-23 36c6-13 14-25 23-36zm303 224c-6-4-10-11-10-18a22 22 0 0 1 30-21c-5 14-12 27-20 39zm26-58c-4-2-8-2-13-2h-3a42 42 0 0 0-22 76c-10 11-20 21-32 29l-2 2A189 189 0 0 1 31 144v1a42 42 0 0 0 45-70c33-33 77-53 126-55 4 15 12 28 24 37a60 60 0 0 0 50 84 60 60 0 0 0 84 50c9 12 22 20 37 24-1 14-3 28-6 41z"/>
+                <path d="M246 314a54 54 0 1 0 0-108 54 54 0 0 0 0 108zm0-88a34 34 0 1 1 0 68 34 34 0 0 1 0-68z"/>
+            </svg>
+            <b-modal id="cookieDecline" title="Decline Google Analytics cookies ?" @ok="cookieDecline" ok-title="Reject" ok-only ok-variant="danger">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-body mx-auto">
+                            <div>
+                                <p>Currently, Google Analytics measures this website's use. You can opt-out to this optional feature by clicking the "Reject" button below.</p>
+                                <b-alert show variant="warning">This action reloads the window</b-alert>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </b-modal>
+            <b-modal id="cookieAccept" title="Accept Google Analytics cookies ?" @ok="cookieAccept" ok-title="Accept" ok-only ok-variant="success">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-body mx-auto">
+                            <div>
+                                <p>Currently, Google Analytics does not measure this website's use. You can opt-in to this optional feature by clicking the "Accept" button below.</p>
+                                <b-alert show variant="warning">This action reloads the window</b-alert>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </b-modal>
+        </div>
+    </div>
+</template>
+<script>
+import 'vue-cookie-accept-decline/dist/vue-cookie-accept-decline.css';
+import VueCookieAcceptDecline from 'vue-cookie-accept-decline';
+import { bootstrap } from 'vue-gtag';
+import { mapState } from 'vuex'
+
+export default {
+    name: 'CookieConsentElement',
+    components: {
+        VueCookieAcceptDecline,
+    },
+    data() {
+        return {
+            user_tracking_consent: null,
+        };
+    },
+    computed: {
+        ...mapState(['theme_color']),
+        cssVars() {
+            return {
+                '--color-main': this.theme_color.main,
+            }
+        }
+    },
+    watch: {
+        user_tracking_consent: function (val) {
+            if (val == 'accept') {
+                // the user has accept Google Analytics tracking
+                // --> load GA
+                // see https://matteo-gabriele.gitbook.io/vue-gtag/v/master/custom-installation#bootstrap-later
+                bootstrap().then(() => { })
+            }
+        }
+    },
+    methods: {
+        cookieStatus(status) {
+            this.user_tracking_consent = status;
+        },
+        cookieClickedAccept() {
+            this.user_tracking_consent = 'accept';
+        },
+        cookieClickedDecline() {
+            this.user_tracking_consent = 'decline';
+        },
+        cookieRemovedCookie() {
+            this.user_tracking_consent = null;
+        },
+        cookieDecline() {
+            this.user_tracking_consent = null;
+            this.$refs.tracking_consent.decline();
+            window.location.reload();
+        },
+        cookieAccept() {
+            this.$refs.tracking_consent.accept();
+            window.location.reload();
+        },
+    }
+}
+</script>
+<style lang="scss">
+#cookie_management {
+    position: relative;
+
+    svg {
+        width: 1rem;
+        position: absolute;
+        right: 1rem;
+        bottom: 1rem;
+        transition: width 100ms;
+    }
+
+    svg:hover{
+        width: 2rem;
+    }
+}
+</style>

--- a/src/components/CurationList.vue
+++ b/src/components/CurationList.vue
@@ -438,6 +438,9 @@ export default {
 
                 // save on the Plazi backend
                 this.saveToPlaziBackend(occurrenceIdToSave);
+
+                //
+                this.$gtag.event('save');
             }
         });
         this.$emitter.on('loginAbort', () => {

--- a/src/components/OccurrencesElement.vue
+++ b/src/components/OccurrencesElement.vue
@@ -72,6 +72,9 @@ import shared_fields from '@/components/shared_fields.js'
                 occurrenceKey: this.occurrence.key
               }
             })
+            this.$gtag.event('displayOccurrence', {
+              occurrenceKey: this.occurrence.key,
+            });
        },
       },
     }

--- a/src/components/OccurrencesList.vue
+++ b/src/components/OccurrencesList.vue
@@ -203,6 +203,7 @@ export default {
                                 if (occ[index].key == this.urls_parameters.occurrence) {
                                     this.updateOccurrencesSelection(occ[index])
                                     this.updateStep(3)
+                                    this.$gtag.event('displayOccurrence');
                                     // this.$router.push({ name: 'HomePage', query: { institutionKey: this.institution_selection.key, datasetKeys: this.datasets_selection.join(','), format: this.format_selection, occurrenceKey: this.urls_parameters.occurrence } }).catch(() => { });
                                 }
                             }

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import App from './App.vue'
 import router from './router'
 import store from './store'
 
-// plugins
+// bootstrap-vue
 import { BootstrapVue, BootstrapVueIcons } from 'bootstrap-vue'
 Vue.use(BootstrapVue);
 Vue.use(BootstrapVueIcons);
@@ -26,6 +26,13 @@ Vue.prototype.$scoring = Scoring;
 Vue.prototype.$backend = Backend;
 Vue.prototype.$orcid = Orcid;
 Vue.prototype.$emitter = mitt();
+
+// vue-gtag
+import VueGtag from "vue-gtag";
+Vue.use(VueGtag, {
+  config: { id: process.env.VUE_APP_GA_ID },
+  bootstrap: false,
+}, router);
 
 new Vue({
   router,

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -59,6 +59,10 @@ export default {
             this.updateStep(2)
             this.$refs.occList.searchOccurrencesAPI(reload)
             this.$router.push({ name: 'HomePage', hash: '#occurrences', query: { institutionKey: this.institution_selection.key, datasetKeys: this.datasets_selection.join(','), format: format }}).catch(()=>{});
+            this.$gtag.event('displayOccurrences_' + format, {
+                institutionKey: this.institution_selection.key,
+                datasetKeys: this.datasets_selection.join(','),
+            });
         },
         reloadOccurrences(){
             this.displayOccurrences(this.format_selection, true)


### PR DESCRIPTION
## Changes in the UI

As long the users do not consent to the tracking, the implementation does not load GA.

![image](https://user-images.githubusercontent.com/1594191/203264994-39fc4496-8a5d-4d21-976d-c7538794116c.png)

Once the users have clicked on "Accept", GA starts to monitor the website activity (as long no browser extension does not block the Google javascript).

The users can update their consent by clicking on the cookie on the bottom right side of the screen:
![image](https://user-images.githubusercontent.com/1594191/203265291-6cdc9cad-b8b3-4b43-a4d6-72aec79c8d7c.png)

![image](https://user-images.githubusercontent.com/1594191/203265592-e772ca19-effa-4a3f-bd1c-c01d82c43c88.png)

## Report

In Google Analytics web site, there are three different data streams: production, sandbox and development : https://support.google.com/analytics/answer/9304153?hl=en


See 
* https://analytics.google.com/analytics/web/#/p342214273/reports/reportinghub
* https://analytics.google.com/analytics/web/#/analysis/p342214273 , click on "Path exploration"

## Technical implementation 

Add two new dependencies:
* [vue-cookie-accept-decline](https://github.com/johndatserakis/vue-cookie-accept-decline#readme) : ask the user consent.
* [vue-gtag, version 1](https://matteo-gabriele.gitbook.io/vue-gtag/v/master/) : Google Analytics for Vue 2.

`VUE_APP_GA_ID` in the `.env` file reference the stream provided by GA.

`src/components/CookieConsentElement.vue` should be reusable in other projects.
