### PR TITLE
Scoring: update scoring, add documentation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src https:; frame-ancestors 'self' https://ebiodiv.org;" />
     <% if (VUE_APP_BASE_URL !== "") { %><base href="<%= VUE_APP_BASE_URL %>" /><%  } %>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,12 +20,12 @@ const routes = [
     component: () => import(/* webpackChunkName: "occurrenceList" */ '../views/OccurrenceListPage.vue')
   },
   {
-    path: '/about',
-    name: 'AboutPage',
+    path: '/scoring',
+    name: 'ScoringPage',
     // route level code-splitting
     // this generates a separate chunk (about.[hash].js) for this route
     // which is lazy-loaded when the route is visited.
-    component: () => import(/* webpackChunkName: "about" */ '../views/AboutPage.vue')
+    component: () => import(/* webpackChunkName: "about" */ '../views/ScoringPage.vue')
   },
   {
     path: '/login',

--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -79,10 +79,6 @@ function get_score_string_jw(subject_value, related_value) {
     return 1 - (new JaroWinkler().distance(subject_value, related_value));
 }
 
-function get_score_string_jw_log(subject_value, related_value) {
-    return get_score_string_jw(subject_value, related_value);
-}
-
 function get_score_string_exact(subject_value, related_value) {
     if (!subject_value || !related_value) {
         return null;
@@ -122,8 +118,10 @@ function get_score_numeric(subject_value, related_value) {
     if (!subject_value || !related_value) {
         return null;
     }
-    const abs_max_value = Math.abs(subject_value, related_value)
-    return 1 - (Math.abs(related_value - subject_value) / abs_max_value)
+    const abs_diff = Math.abs(subject_value - related_value);
+    const log_abs_diff = Math.log(abs_diff + 1);
+    const max_log_abs_diff = Math.min(log_abs_diff, 7);
+    return (7 - max_log_abs_diff) / 7;
 }
 
 function get_score_elevation(subject_value, related_value) {
@@ -259,7 +257,6 @@ export default new class Scoring {
     static FIELDS = [
         new FieldDescription("typeStatus", 2, normalize_str, get_score_string_exact),
         new FieldDescription("basisOfRecord", 2, normalize_str, get_score_string_exact),
-        new FieldDescription("basisOfRecord", 2, normalize_str, get_score_string_exact),
         new FieldDescription("recordedBy", 2, normalize_str, get_score_string_jw),
         new FieldDescription("recordNumber", 2, normalize_str, get_score_string_exact),
         new FieldDescription("recordedByIDs", 2, normalize_recordedbyids, get_score_recordedbyids),
@@ -271,15 +268,57 @@ export default new class Scoring {
         new FieldDescription("specificEpithet", 1, normalize_str, get_score_string_jw),
         new FieldDescription("country", 1, normalize_str, get_score_string_exact),  // the value is normalized by GBIF, there is no typo
         new FieldDescription("city", 1, normalize_str_or_null, get_score_string_jw),
-        new FieldDescription("locality", 0.5, normalize_str_or_null, get_score_string_jw_log),
+        new FieldDescription("locality", 0.5, normalize_str_or_null, get_score_string_jw),
         new FieldDescription("elevation", 0.5, normalize_int, get_score_elevation),
         new MultiFieldsDescription(["year", "month", "day"], 1, normalize_yearmonthday, get_score_yearmonthday),
         new MultiFieldsDescription(["decimalLatitude", "decimalLongitude"], 2, normalize_latlon, get_score_latlon),
     ]
 
+    static F_SCORE_DESC = {
+        get_score_string_exact: "Exact match",
+        get_score_string_jw: `String distance using the <a href="https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance">Jaro-Winkler algorithm</a>`,
+        get_score_recordedbyids: `This field is a list of identifiers. If at least one identifier exists in the two lists, then the score is 1 otherwise, the score is 0`,
+        get_score_string_exact_or_include: "Keep only the alphanumeric characters and then compare the values for either an exact match or substring",
+        get_score_numeric: `Score using log(difference + 1):
+        <ul>
+            <li>the score is 1 when the difference is 0</li>
+            <li>the score is 0.66 when the difference is 10</li>
+            <li>the score is 0.34 when the difference is 100</li>
+            <li>the score is 0.11 when the difference is 500</li>
+        </ul>`,
+        get_score_elevation: `Score according to the difference between the two elevations:
+        <ul>
+            <li>the score is 1 when the elevations are equals</li>
+            <li>the score is 0.88 when there is a 1 meter difference</li>
+            <li>the score is 0.6 when there is a 10 meters difference</li>
+            <li>the score is 0.23 when there is a 100 meters difference</li>
+            <li>the score is 0.04 when there is a 400 meters difference</li>
+        </ul>`,
+        get_score_yearmonthday: `Score according to the number of days between the two dates:
+        <ul>
+            <li>the score is 1 when the dates are equals</li>
+            <li>the score is 0.9 when there is 1 day distance</li>
+            <li>the score is 0.5 when there is 7 days distance</li>
+            <li>the score is 0.22 when there is on 15 days distance</li>
+        </ul>`,
+        get_score_latlon: `Get the <a href="https://en.wikipedia.org/wiki/Haversine_formula">Haversine distance</a>:
+        <ul>
+            <li>the score is 1 when the distance is 0</li>
+            <li>the score is 0.98 when the distance is 2km</li>
+            <li>the score is 0.92 when the distance is 10km</li>
+            <li>the score is 0.89 when the distance is 15km</li>
+            <li>the score is 0.79 when the distance is 30km</li>
+            <li>the score is 0.45 when the distance is 100km</li>
+            <li>the score is 0.21 when the distance is 200km</li>
+            <li>the score is 0.09 when the distance is 300km</li>
+        </ul>`,
+    }
+
     constructor() {
         this.occurrence_cache = {}
         this.score_cache = {}
+        this.FIELDS = Scoring.FIELDS
+        this.F_SCORE_DESC = Scoring.F_SCORE_DESC
     }
 
     get_scores(occurrences1, occurrences2) {

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -1,5 +1,0 @@
-<template>
-  <div class="about">
-    <h1>This is an about page</h1>
-  </div>
-</template>

--- a/src/views/ScoringPage.vue
+++ b/src/views/ScoringPage.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="container-fluid">
+    <b-row>
+      <b-col>
+        <b-table
+          striped
+          hover
+          id="fields"
+          :items="field_items"
+          :fields="fields"
+          primary-key="GBIF_fields">
+          <template #cell(description)="data">
+            <span v-html="data.value"></span>
+          </template>
+        </b-table>
+      </b-col>
+    </b-row>
+  </div>
+</template>
+<script>
+// @ is an alias to /src
+import { mapState } from 'vuex'
+
+
+export default {
+  name: 'HomePage',
+  data (){
+    return {
+      fields: [
+        { key: 'order', sortable: true},
+        { key: 'name', sortable: true},
+        { key: 'GBIF_fields', sortable: true },
+        { key: 'weight', sortable: true },
+        { key: 'description', sortable: true }
+      ]
+    };
+  },
+  computed: {
+    ...mapState(['curation_characteristics']),
+    field_items() {
+      let field_descriptions = {}
+      for (const fd of this.$scoring.FIELDS) {
+        let key = fd.field_name;
+        let field_names = fd.field_name;
+        const get_score_function_name = fd.get_score_function.name;
+        const get_score_function_desc = this.$scoring.F_SCORE_DESC[get_score_function_name];
+        if (Array.isArray(field_names)) {
+          key = field_names[0];
+          field_names = field_names.join(", ");
+        }
+        field_descriptions[key] = {
+          GBIF_fields: field_names,
+          weight: fd.weight,
+          description: get_score_function_desc,
+        };
+      }
+
+      let rows = [];
+      let i = 1;
+      for (const cc of this.curation_characteristics) {
+        rows.push({
+          order: i,
+          name: cc.name,
+          ...field_descriptions[cc.score]
+        });
+        i++;
+      }
+      return rows;
+    },
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.container-fluid {
+  padding-right: 0px;
+  padding-left: 0px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.row {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.col {
+  padding: 0;
+}
+
+#fields {
+  text-align: left;
+}
+</style>


### PR DESCRIPTION
Add `/scoring` URL, the page has no header on purpose:
![image](https://user-images.githubusercontent.com/1594191/213259769-b84b3907-8f18-4076-b92e-9c76f2a10100.png)

ebiodiv.org can include `/scoring` in an iframe:
![image](https://user-images.githubusercontent.com/1594191/213259728-4d4837b0-56c7-4559-bf74-33cfccc40d55.png)
